### PR TITLE
Throw exception on JSON-RPC error in endpoint discovery

### DIFF
--- a/NutshellApi.php
+++ b/NutshellApi.php
@@ -160,6 +160,9 @@ class NutshellApi {
 		curl_close($curl);
 
 		$decoded = $this->json_decode($result);
+		if ($decoded->error !== NULL) {
+			throw new NutshellApiException($decoded->error->message);
+		}
 		return 'https://' . $decoded->result->api . '/api/v1/json';
 	}
 	


### PR DESCRIPTION
Inspired by an issue @csustaita diagnosed with a user who was disabled but trying to use [nutshellcrm/nutshell-api-php](https://github.com/nutshellcrm/nutshell-api-php/).