### PR TITLE
Adds MIT license to root

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 Nutshell, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Read the comments in `NutshellApi.php` for additional information about the clas
 
 The `NutshellApi` class provides synchronous (blocking) API calls. It is possible to write an API class which provides asynchronous calls using the `id` field specified in [JSON-RPC](http://groups.google.com/group/json-rpc/web/json-rpc-2-0).
 
+This project is [covered by the MIT software license.](LICENSE.txt)
+
 ## Composer
 
 Thanks to the community [for nudging us to make this code compatible with Composer](https://github.com/nutshellcrm/nutshell-api-php/pull/5). While it's not meant to be a fully-supported SDK, you can use [composer](https://getcomposer.org/) to quickly add this project to your own.


### PR DESCRIPTION
We had a customer asking about using this project as the basis for a product that could conceivably become a commercial product. We already [declare MIT in the `composer.json`](https://github.com/nutshellcrm/nutshell-api-php/blob/079139089498495feccacb1712949d1c8571929c/composer.json#L5), this just makes it a bit more official.